### PR TITLE
Added port to modbus tcp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Inputs
 
 Outputs
 -------
-- **default**: Notifies a signal for each frame read from Modbus. See example below.
+- **default**: Notifies a signal for each frame read from Modbus.
 
 Commands
 --------
@@ -43,6 +43,7 @@ Properties
 - **enrich**: If true, the incoming signal will be attached to the output signal.
 - **function_name**: Modbus function call to execute.
 - **host**: The host to connect to.
+- **port**: The port to connect to.
 - **retry**: How many times to retry connection on failure.
 - **retry_options**: Configurables for retry attempts.
 - **unit_id**: ID of modbus unit
@@ -54,7 +55,7 @@ Inputs
 
 Outputs
 -------
-- **default**: Notifies a signal for each frame read from Modbus. See example below.
+- **default**: Notifies a signal for each frame read from Modbus.
 
 Commands
 --------

--- a/modbus_tcp_block.py
+++ b/modbus_tcp_block.py
@@ -116,8 +116,9 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
         if host:
             self._connect_to_host(host, port)
         else:
-            for host in self._clients:
-                self._connect_to_host(self._clients[host].host, self._clients[host].port)
+            for index in self._clients:
+                indexVars = index.split(":")
+                self._connect_to_host(indexVars[0], int(indexVars[1]))
 
     def _connect_to_host(self, host, port):
         self.logger.debug('Connecting to modbus host: {}'.format(host))

--- a/spec.json
+++ b/spec.json
@@ -119,6 +119,12 @@
         "description": "The host to connect to.",
         "default": "127.0.0.1"
       },
+      "port": {
+        "title": "Port",
+        "type": "IntType",
+        "description": "The port to connect to.",
+        "default": 502
+      },
       "retry": {
         "title": "Number of Retries before Error",
         "type": "IntType",

--- a/tests/test_modbus_tcp_block.py
+++ b/tests/test_modbus_tcp_block.py
@@ -37,11 +37,11 @@ class TestModbusTCP(NIOBlockTestCase):
         self.configure_block(blk, {})
         self.assertEqual(mock_client.call_count, 1)
         # Simulate some response from the modbus read
-        blk._client(blk.host()).read_coils.return_value = SampleResponse()
+        blk._client(blk.host(),blk.port()).read_coils.return_value = SampleResponse()
         blk.start()
         # Read once and assert output
         blk.process_signals([Signal()])
-        blk._client(blk.host()).read_coils.assert_called_once_with(
+        blk._client(blk.host(),blk.port()).read_coils.assert_called_once_with(
             address=0, count=1, unit=1)
         self.assertTrue(len(self.last_notified[DEFAULT_TERMINAL]))
         self.assertEqual(
@@ -55,11 +55,11 @@ class TestModbusTCP(NIOBlockTestCase):
         self.configure_block(blk, {"enrich": {"exclude_existing": False}})
         self.assertEqual(mock_client.call_count, 1)
         # Simulate some response from the modbus read
-        blk._client(blk.host()).read_coils.return_value = SampleResponse()
+        blk._client(blk.host(),blk.port()).read_coils.return_value = SampleResponse()
         blk.start()
         # Read once and assert output
         blk.process_signals([Signal({"input": "signal"})])
-        blk._client(blk.host()).read_coils.assert_called_once_with(
+        blk._client(blk.host(),blk.port()).read_coils.assert_called_once_with(
             address=0, count=1, unit=1)
         self.assertTrue(len(self.last_notified[DEFAULT_TERMINAL]))
         self.assertDictEqual(
@@ -85,7 +85,7 @@ class TestModbusTCP(NIOBlockTestCase):
         # Connect and read from first client
         signal1 = Signal({"host": "host1"})
         blk.process_signals([signal1])
-        blk._client(blk.host(signal1)).read_coils.assert_called_once_with(
+        blk._client(blk.host(signal1),blk.port()).read_coils.assert_called_once_with(
             address=0, count=1, unit=1)
         self.assertEqual(mock_client.call_count, 1)
         # Connect and read from second client
@@ -105,12 +105,12 @@ class TestModbusTCP(NIOBlockTestCase):
         self.configure_block(blk, {'function_name': 'write_coil'})
         self.assertEqual(mock_client.call_count, 1)
         # Simulate some response from the modbus read
-        blk._client(blk.host()).write_coil.return_value = SampleResponse()
+        blk._client(blk.host(),blk.port()).write_coil.return_value = SampleResponse()
         blk.start()
         # Read once and assert output
         blk.process_signals([Signal()])
-        self.assertEqual(blk._client(blk.host()).write_coil.call_count, 1)
-        blk._client(blk.host()).write_coil.assert_called_once_with(
+        self.assertEqual(blk._client(blk.host(),blk.port()).write_coil.call_count, 1)
+        blk._client(blk.host(),blk.port()).write_coil.assert_called_once_with(
             address=0, value=True, unit=1)
         self.assertTrue(len(self.last_notified[DEFAULT_TERMINAL]))
         self.assertEqual(
@@ -124,12 +124,12 @@ class TestModbusTCP(NIOBlockTestCase):
         self.configure_block(blk, {'function_name': '{{ $function }}'})
         self.assertEqual(mock_client.call_count, 1)
         # Simulate some response from the modbus read
-        blk._client(blk.host()).write_coils.return_value = SampleResponse()
+        blk._client(blk.host(),blk.port()).write_coils.return_value = SampleResponse()
         blk.start()
         # Read once and assert output
         blk.process_signals([Signal({'function': 'write_multiple_coils'})])
-        self.assertEqual(blk._client(blk.host()).write_coils.call_count, 1)
-        blk._client(blk.host()).write_coils.assert_called_once_with(
+        self.assertEqual(blk._client(blk.host(),blk.port()).write_coils.call_count, 1)
+        blk._client(blk.host(),blk.port()).write_coils.assert_called_once_with(
             address=0, values=True, unit=1)
         self.assertTrue(len(self.last_notified[DEFAULT_TERMINAL]))
         self.assertEqual(
@@ -144,7 +144,7 @@ class TestModbusTCP(NIOBlockTestCase):
         # Simulate some exception response from the modbus read
         resp = SampleResponse()
         resp.exception_code = 2
-        blk._client(blk.host()).read_coils.return_value = resp
+        blk._client(blk.host(),blk.port()).read_coils.return_value = resp
         blk.start()
         # Read once and assert output
         blk.process_signals([Signal()])
@@ -161,13 +161,13 @@ class TestModbusTCP(NIOBlockTestCase):
         self.configure_block(blk, {'retry_options': {'multiplier': 0}})
         self.assertEqual(mock_client.call_count, 1)
         # Simulate an exception and then a success.
-        blk._client(blk.host()).read_coils.side_effect = \
+        blk._client(blk.host(),blk.port()).read_coils.side_effect = \
             [Exception, SampleResponse()]
         blk.start()
         # Read once and then retry.
         blk.process_signals([Signal()])
         # Modbus function is called twice. Once for the retry.
-        self.assertEqual(blk._client(blk.host()).read_coils.call_count, 2)
+        self.assertEqual(blk._client(blk.host(),blk.port()).read_coils.call_count, 2)
         # A signal is output because of successful retry.
         self.assertTrue(bool(len(self.last_notified[DEFAULT_TERMINAL])))
         self.assertEqual(
@@ -183,7 +183,7 @@ class TestModbusTCP(NIOBlockTestCase):
         self.configure_block(blk, {
             "enrich": {"exclude_existing": False},
             "retry_options": {"multiplier": 0}})
-        blk._client(blk.host()).read_coils.side_effect = Exception
+        blk._client(blk.host(),blk.port()).read_coils.side_effect = Exception
         blk.start()
         blk.process_signals([Signal({'input': 'signal'})])
         self.assertDictEqual(


### PR DESCRIPTION
self._clients has keys in the format of "{{host}}:{{port}}" now, and a port field has been added to the block configuration