### PR TITLE
Add timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ None
 Dependencies
 ------------
 -   [minimalmodbus](https://pypi.python.org/pypi/MinimalModbus)
--   [pymodbus3](https://pypi.python.org/pypi/pymodbus3/1.0.0)
+-   [pymodbus](https://pypi.org/project/pymodbus/1.3.1/)
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -1,74 +1,12 @@
-ModbusRTU
-=========
-Communicate with a Modbus device over RTU Serial.
+modbus
+===
 
-Properties
-----------
-- **address**: The starting address to read from or write to.
-- **count**: The number of coils/discretes/registers to read.
-- **function_name**: Modbus function call to execute.
-- **port_config**: The modbus port to connect to (default 502). If left blank, the default pymodbus3 value will be used.
-- **retry**: How many times to retry connection on failure.
-- **retry_options**: Configurables for retry attempts.
-- **slave_address**: Slave address of modbus device.
-- **value**: The value to write to the specified address.
-
-Inputs
-------
-- **default**: Drive reads and writes with input signals.
-
-Outputs
--------
-- **default**: Notifies a signal for each frame read from Modbus.
-
-Commands
---------
-None
+Blocks in this Collection
+---
+[ModbusRTU](docs/modbus_rtu.md)
+[ModbusTCP](docs/modbus_tcp.md)
 
 Dependencies
-------------
--   [minimalmodbus](https://pypi.python.org/pypi/MinimalModbus)
--   [pymodbus](https://pypi.org/project/pymodbus/1.3.1/)
-
-***
-
-ModbusTCP
-=========
-Communicate with a device using Modbus TCP.
-
-Properties
-----------
-- **address**: The starting address to read from or write to.
-- **count**: Number of coils/registers to read
-- **enrich**: If true, the incoming signal will be attached to the output signal.
-- **function_name**: Modbus function call to execute.
-- **host**: The host to connect to.
-- **port**: The port to connect to.
-- **retry**: How many times to retry connection on failure.
-- **retry_options**: Configurables for retry attempts.
-- **unit_id**: ID of modbus unit
-- **value**: The value to write to the specified address.
-
-Inputs
-------
-- **default**: Drive reads and writes with input signals.
-
-Outputs
--------
-- **default**: Notifies a signal for each frame read from Modbus.
-
-Commands
---------
-None
-
-Output Example
---------------
-Attributes on signals include (but are not limited to) the following:
-  - `params`: Dictionary of parameters passed to function call.
-    - `register_address`: Starting address.
-    - `function_code`: Modbus function code.
-    - `value` (optional): Value on write.
-  - `values` (optional): List of int values when reading registers.
-  - `exception_code` (int, optional): Error code when function call is invalid.
-  - `exception_details` (str, optional): Error details when function call is invalid.
-
+---
+ - [minimalmodbus](https://pypi.python.org/pypi/MinimalModbus)
+ - [pymodbus](https://pypi.org/project/pymodbus/1.3.1/)

--- a/docs/modbus_rtu.md
+++ b/docs/modbus_rtu.md
@@ -1,0 +1,19 @@
+ModbusRTU
+=========
+Communicate with a Modbus/RTU device over serial. This block will open a comm port on the host machine (configurable parameters) and send a request for every signal processed. Responses will be emitted as signals containing the raw register values as a list of 16-bit integers or bits (booleans).
+
+See also: The [*Replicator*](https://blocks.n.io/Replicator) block is useful for putting each register into its own signal.
+
+Properties
+----------
+- **Slave Address**: Bus address of target slave device. Valid Modbus address are 1 thru 247, or 0 for broadcast.
+- **Function Name**: Select one of the standard Modbus functions.
+- **Starting Address**: Starting register number to read or write. Address offsets are handled by the selected **Function Name**. For example, if selecting the function *Read Holding Registers* the register address `0` corresponds to register `40001` in the target device.
+- **Number of coils/registers to read**: How many values to read in total, including the **Starting Address**. The outgoing signal will contain this many values in a list. Not used when writing values.
+- **Write Values(s)**: A list of values to write to the target device. Each value will be written to a consecutive register or coil starting from **Starting Address**. The number of values to write is the length of the list. Not used when reading values.
+- **Timeout**: (Advanced) Seconds to wait for a response before failing and executing **Retry Options** configuration.
+- **Port Config**: (Advanced) Serial configurations here must be compatible with the target device. Thwe value of **Serial Port** depends on the host operating system, in Windows this is often something like `COM1`, and in POSIX-based systems `/dev/ttyS0` or similar.
+
+Commands
+--------
+None

--- a/docs/modbus_tcp.md
+++ b/docs/modbus_tcp.md
@@ -1,0 +1,32 @@
+ModbusTCP
+=========
+Communicate with a Modbus/TCP device. This block will manage connections to slave devices and send a request for every signal processed. Responses will be emitted as signals containing the raw register values as a list of 16-bit integers or bits (booleans).
+
+See also: The [*Replicator*](https://blocks.n.io/Replicator) block is useful for putting each register into its own signal.
+
+Properties
+----------
+- **Host**: Host address of slave device.
+- **Port**: TCP port of slave device.
+- **Unit ID**: Unit ID of slave, defaults to 1.
+- **Function Name**: Select one of the standard Modbus functions.
+- **Starting Address**: Starting register number to read or write. Address offsets are handled by the selected **Function Name**. For example, if selecting the function *Read Holding Registers* the register address `0` corresponds to register `40001` in the target device.
+- **Number of coils/registers to read**: How many values to read in total, including the **Starting Address**. The outgoing signal will contain this many values in a list. Not used when writing values.
+- **Write Values(s)**: A list of values to write to the target device. Each value will be written to a consecutive register or coil starting from **Starting Address**. The number of values to write is the length of the list. Not used when reading values.
+- **Timeout**: (Advanced) Seconds to wait for a response before failing and executing **Retry Options** configuration.
+
+Example
+---
+Attributes on outgoing signals include (but are not limited to) the following:
+  - `params`: Dictionary of parameters passed to function call.
+    - `register_address`: Starting address.
+    - `function_code`: Modbus function code.
+    - `value` (optional): Value on write.
+  - `values` (optional): List of int values when reading coils.
+  - `registers` (optional): list of 16-bit integer values when reading registers.
+  - `exception_code` (int, optional): Error code when function call is invalid.
+  - `exception_details` (str, optional): Error details when function call is invalid.
+
+Commands
+--------
+None

--- a/modbus_rtu_block.py
+++ b/modbus_rtu_block.py
@@ -50,9 +50,6 @@ class ModbusRTU(Retry, Block):
     count = IntProperty(title='Number of coils/registers to read',
                         default=1)
     value = Property(title='Write Value(s)', default='{{ True }}')
-    retry = IntProperty(title='Number of Retries before Error',
-                        default=10,
-                        visible=False)
     port_config = ObjectProperty(
         PortConfig, title="Serial Port Setup", default=PortConfig())
 

--- a/modbus_rtu_block.py
+++ b/modbus_rtu_block.py
@@ -6,7 +6,7 @@ from time import sleep
 from nio.block.base import Block
 from nio.block.mixins.retry.retry import Retry
 from nio.signal.base import Signal
-from nio.properties import StringProperty, IntProperty, \
+from nio.properties import StringProperty, IntProperty, FloatProperty, \
     Property, VersionProperty, SelectProperty, PropertyHolder, ObjectProperty
 
 
@@ -26,7 +26,6 @@ class PortConfig(PropertyHolder):
     parity = StringProperty(title='Parity (N, E, O)', default='N', order=23)
     bytesize = IntProperty(title='Byte Size', default=8, order=22)
     stopbits = IntProperty(title='Stop Bits', default=1, order=24)
-    timeout = Property(title='Timeout', default='0.05', order=25)
     port = StringProperty(title='Serial Port',
                           default='/dev/ttyUSB0',
                           order=20)
@@ -39,6 +38,7 @@ class ModbusRTU(Retry, Block):
     Parameters:
         slave_address (str): Slave address of modbus device.
         port (str): Serial port modbus device is connected to.
+        timeout (float): Seconds to wait for a response before failing.
     """
 
     version = VersionProperty("0.1.2")
@@ -56,6 +56,8 @@ class ModbusRTU(Retry, Block):
                                  title="Serial Port Setup",
                                  default=PortConfig(),
                                  advanced=True)
+    timeout = FloatProperty(title='Timeout', default='0.05', advanced=True)
+
 
     def __init__(self):
         super().__init__()
@@ -97,7 +99,7 @@ class ModbusRTU(Retry, Block):
         minimalmodbus.PARITY = self.port_config().parity()
         minimalmodbus.BYTESIZE = self.port_config().bytesize()
         minimalmodbus.STOPBITS = self.port_config().stopbits()
-        minimalmodbus.TIMEOUT = float(self.port_config().timeout())
+        minimalmodbus.TIMEOUT = float(self.timeout())
         self._client = minimalmodbus.Instrument(self.port_config().port(),
                                                 self.slave_address())
         self.logger.debug(self._client)

--- a/modbus_rtu_block.py
+++ b/modbus_rtu_block.py
@@ -22,12 +22,14 @@ class FunctionName(Enum):
 
 
 class PortConfig(PropertyHolder):
-    baudrate = IntProperty(title='Baud Rate', default=19200)
-    parity = StringProperty(title='Parity (N, E, O)', default='N')
-    bytesize = IntProperty(title='Byte Size', default=8)
-    stopbits = IntProperty(title='Stop Bits', default=1)
-    timeout = Property(title='Timeout', default='0.05')
-    port = StringProperty(title='Serial Port', default='/dev/ttyUSB0')
+    baudrate = IntProperty(title='Baud Rate', default=19200, order=21)
+    parity = StringProperty(title='Parity (N, E, O)', default='N', order=23)
+    bytesize = IntProperty(title='Byte Size', default=8, order=22)
+    stopbits = IntProperty(title='Stop Bits', default=1, order=24)
+    timeout = Property(title='Timeout', default='0.05', order=25)
+    port = StringProperty(title='Serial Port',
+                          default='/dev/ttyUSB0',
+                          order=20)
 
 
 class ModbusRTU(Retry, Block):

--- a/modbus_rtu_block.py
+++ b/modbus_rtu_block.py
@@ -99,7 +99,7 @@ class ModbusRTU(Retry, Block):
         minimalmodbus.PARITY = self.port_config().parity()
         minimalmodbus.BYTESIZE = self.port_config().bytesize()
         minimalmodbus.STOPBITS = self.port_config().stopbits()
-        minimalmodbus.TIMEOUT = float(self.timeout())
+        minimalmodbus.TIMEOUT = self.timeout()
         self._client = minimalmodbus.Instrument(self.port_config().port(),
                                                 self.slave_address())
         self.logger.debug(self._client)

--- a/modbus_rtu_block.py
+++ b/modbus_rtu_block.py
@@ -40,18 +40,20 @@ class ModbusRTU(Retry, Block):
     """
 
     version = VersionProperty("0.1.2")
-    slave_address = IntProperty(title='Slave Address', default=1)
-    function_name = SelectProperty(
-        FunctionName,
-        title='Function Name',
-        default=FunctionName.read_input_registers
-    )
-    address = Property(title='Starting Address', default='0')
+    slave_address = IntProperty(title='Slave Address', default=1, order=10)
+    function_name = SelectProperty(FunctionName,
+                                   title='Function Name',
+                                   default=FunctionName.read_input_registers,
+                                   order=11)
+    address = Property(title='Starting Address', default='0', order=12)
     count = IntProperty(title='Number of coils/registers to read',
-                        default=1)
-    value = Property(title='Write Value(s)', default='{{ True }}')
-    port_config = ObjectProperty(
-        PortConfig, title="Serial Port Setup", default=PortConfig())
+                        default=1,
+                        order=13)
+    value = Property(title='Write Value(s)', default='{{ True }}', order=14)
+    port_config = ObjectProperty(PortConfig,
+                                 title="Serial Port Setup",
+                                 default=PortConfig(),
+                                 advanced=True)
 
     def __init__(self):
         super().__init__()

--- a/modbus_tcp_block.py
+++ b/modbus_tcp_block.py
@@ -39,9 +39,6 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
                                    default=FunctionName.read_coils)
     address = IntProperty(title='Starting Address', default=0)
     value = Property(title='Write Value(s)', default='{{ True }}')
-    retry = IntProperty(title='Number of Retries before Error',
-                        default=10,
-                        visible=False)
     count = IntProperty(title='Number of coils/registers to read',
                         default=1)
     unit_id = IntProperty(title='Unit ID', default=1)
@@ -49,7 +46,6 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
     def __init__(self):
         super().__init__()
         self._clients = {}
-        self._retry_failed = False
 
     def configure(self, context):
         super().configure(context)

--- a/modbus_tcp_block.py
+++ b/modbus_tcp_block.py
@@ -5,7 +5,7 @@ from time import sleep
 
 from nio.block.base import Block
 from nio.properties import IntProperty, Property, VersionProperty, \
-    SelectProperty
+    SelectProperty, FloatProperty
 from nio.block.mixins.limit_lock.limit_lock import LimitLock
 from nio.block.mixins.retry.retry import Retry
 from nio.block.mixins.enrich.enrich_signals import EnrichSignals
@@ -29,6 +29,7 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
     Parameters:
         host (str): The host to connect to.
         port (int): The modbus port to connect to.
+        timeout (float): Seconds to wait for a response before failing.
     """
 
     version = VersionProperty("0.2.0")
@@ -42,6 +43,7 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
     count = IntProperty(title='Number of coils/registers to read',
                         default=1)
     unit_id = IntProperty(title='Unit ID', default=1)
+    timeout = FloatProperty(title='Timeout', default=1, advanced=True)
 
     def __init__(self):
         super().__init__()
@@ -118,7 +120,10 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
 
     def _connect_to_host(self, host, port):
         self.logger.debug('Connecting to modbus host: {}'.format(host))
-        self._clients['{}:{}'.format(host,port)] = pymodbus.client.sync.ModbusTcpClient(host, port=port)
+        client = pymodbus.client.sync.ModbusTcpClient(host,
+                                                      port=port,
+                                                      timeout=self.timeout())
+        self._clients['{}:{}'.format(host,port)] = client
         self.logger.debug(
             'Succesfully connected to modbus host: {}'.format(host))
 

--- a/modbus_tcp_block.py
+++ b/modbus_tcp_block.py
@@ -1,5 +1,5 @@
 import logging
-import pymodbus3.client.sync
+import pymodbus.client.sync
 from enum import Enum
 from time import sleep
 
@@ -53,8 +53,8 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
 
     def configure(self, context):
         super().configure(context)
-        # We don't need pymodbus3 to log for us. The block will handle that.
-        logging.getLogger('pymodbus3').setLevel(logging.CRITICAL)
+        # We don't need pymodbus to log for us. The block will handle that.
+        logging.getLogger('pymodbus').setLevel(logging.CRITICAL)
         # Make sure host is able to evaluate without a signal before connecting
         try:
             host = self.host()
@@ -122,7 +122,7 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
 
     def _connect_to_host(self, host, port):
         self.logger.debug('Connecting to modbus host: {}'.format(host))
-        self._clients['{}:{}'.format(host,port)] = pymodbus3.client.sync.ModbusTcpClient(host, port=port)
+        self._clients['{}:{}'.format(host,port)] = pymodbus.client.sync.ModbusTcpClient(host, port=port)
         self.logger.debug(
             'Succesfully connected to modbus host: {}'.format(host))
 

--- a/modbus_tcp_block.py
+++ b/modbus_tcp_block.py
@@ -32,17 +32,19 @@ class ModbusTCP(LimitLock, EnrichSignals, Retry, Block):
         timeout (float): Seconds to wait for a response before failing.
     """
 
-    version = VersionProperty("0.2.0")
-    host = Property(title='Host', default='127.0.0.1')
-    port = IntProperty(title='Port', default=502)
+    version = VersionProperty("0.2.0", order=100)
+    host = Property(title='Host', default='127.0.0.1', order=10)
+    port = IntProperty(title='Port', default=502, order=11)
     function_name = SelectProperty(FunctionName,
                                    title='Function Name',
-                                   default=FunctionName.read_coils)
-    address = IntProperty(title='Starting Address', default=0)
-    value = Property(title='Write Value(s)', default='{{ True }}')
+                                   default=FunctionName.read_coils,
+                                   order=13)
+    address = IntProperty(title='Starting Address', default=0, order=14)
+    value = Property(title='Write Value(s)', default='{{ True }}', order=16)
     count = IntProperty(title='Number of coils/registers to read',
-                        default=1)
-    unit_id = IntProperty(title='Unit ID', default=1)
+                        default=1,
+                        order=15)
+    unit_id = IntProperty(title='Unit ID', default=1, order=12)
     timeout = FloatProperty(title='Timeout', default=1, advanced=True)
 
     def __init__(self):

--- a/release.json
+++ b/release.json
@@ -1,12 +1,12 @@
 {
   "nio/ModbusRTU": {
     "language": "Python",
-    "version": "0.1.2",
+    "from_pyhton": "modbus_rtu_block.ModbusRTU",
     "url": "git://github.com/nio-blocks/modbus.git"
   },
   "nio/ModbusTCP": {
     "language": "Python",
-    "version": "0.2.0",
+    "from_python": "modbus_tcp_block.ModbusTCP",
     "url": "git://github.com/nio-blocks/modbus.git"
   }
 }

--- a/release.json
+++ b/release.json
@@ -1,10 +1,12 @@
 {
   "nio/ModbusRTU": {
+    "version": "1.0.0",
     "language": "Python",
     "from_pyhton": "modbus_rtu_block.ModbusRTU",
     "url": "git://github.com/nio-blocks/modbus.git"
   },
   "nio/ModbusTCP": {
+    "version": "1.0.0",
     "language": "Python",
     "from_python": "modbus_tcp_block.ModbusTCP",
     "url": "git://github.com/nio-blocks/modbus.git"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymodbus3~=1.0
+pymodbus~=1.3.1
 minimalmodbus~=0.7
 pyserial~=3.2

--- a/spec.json
+++ b/spec.json
@@ -4,7 +4,7 @@
     "categories": [
       "Hardware"
     ],
-    "tags": "",
+    "tags": "serial",
     "from_readme": "docs/modbus_rtu.md",
     "from_python": "modbus_rtu_block.ModbusRTU"
   },
@@ -13,8 +13,8 @@
     "categories": [
       "Hardware"
     ],
-    "tags": "".
-    "from_readme": "docs/modbus_tcp.md"
+    "tags": "",
+    "from_readme": "docs/modbus_tcp.md",
     "from_python": "modbus_tcp_block.ModbusTCP"
   }
 }

--- a/spec.json
+++ b/spec.json
@@ -1,170 +1,20 @@
 {
   "nio/ModbusRTU": {
-    "version": "0.1.2",
-    "description": "Communicate with a Modbus device over RTU Serial.",
+    "description": "Communicate with a Modbus/RTU device over serial.",
     "categories": [
       "Hardware"
     ],
-    "properties": {
-      "address": {
-        "title": "Starting Address",
-        "type": "Type",
-        "description": "The starting address to read from or write to.",
-        "default": "0"
-      },
-      "count": {
-        "title": "Number of coils/registers to read",
-        "type": "IntType",
-        "description": "The number of coils/discretes/registers to read.",
-        "default": 1
-      },
-      "function_name": {
-        "title": "Function Name",
-        "type": "SelectType",
-        "description": "Modbus function call to execute.",
-        "default": 4
-      },
-      "port_config": {
-        "title": "Serial Port Setup",
-        "type": "ObjectType",
-        "description": "The modbus port to connect to (default 502). If left blank, the default pymodbus3 value will be used.",
-        "default": {
-          "baudrate": 19200,
-          "parity": "N",
-          "bytesize": 8,
-          "stopbits": 1,
-          "timeout": "0.05",
-          "port": "/dev/ttyUSB0"
-        }
-      },
-      "retry": {
-        "title": "Number of Retries before Error",
-        "type": "IntType",
-        "description": "How many times to retry connection on failure.",
-        "default": 10
-      },
-      "retry_options": {
-        "title": "Retry Options",
-        "type": "ObjectType",
-        "description": "Configurables for retry attempts.",
-        "default": {
-          "strategy": "linear",
-          "max_retry": 5,
-          "multiplier": 1,
-          "indefinite": false
-        }
-      },
-      "slave_address": {
-        "title": "Slave Address",
-        "type": "IntType",
-        "description": "Slave address of modbus device.",
-        "default": 1
-      },
-      "value": {
-        "title": "Write Value(s)",
-        "type": "Type",
-        "description": "The value to write to the specified address.",
-        "default": "{{ True }}"
-      }
-    },
-    "inputs": {
-      "default": {
-        "description": "Drive reads and writes with input signals."
-      }
-    },
-    "outputs": {
-      "default": {
-        "description": "Notifies a signal for each frame read from Modbus."
-      }
-    },
-    "commands": {}
+    "tags": "",
+    "from_readme": "docs/modbus_rtu.md",
+    "from_python": "modbus_rtu_block.ModbusRTU"
   },
   "nio/ModbusTCP": {
-    "version": "0.2.0",
-    "description": "Communicate with a device using Modbus TCP.",
+    "description": "Communicate with a device using Modbus/TCP.",
     "categories": [
       "Hardware"
     ],
-    "properties": {
-      "address": {
-        "title": "Starting Address",
-        "type": "IntType",
-        "description": "The starting address to read from or write to.",
-        "default": 0
-      },
-      "count": {
-        "title": "Number of coils/registers to read",
-        "type": "IntType",
-        "description": "Number of coils/registers to read",
-        "default": 1
-      },
-      "enrich": {
-        "title": "Signal Enrichment",
-        "type": "ObjectType",
-        "description": "If true, the incoming signal will be attached to the output signal.",
-        "default": {
-          "enrich_field": "",
-          "exclude_existing": true
-        }
-      },
-      "function_name": {
-        "title": "Function Name",
-        "type": "SelectType",
-        "description": "Modbus function call to execute.",
-        "default": "read_coils"
-      },
-      "host": {
-        "title": "Host",
-        "type": "Type",
-        "description": "The host to connect to.",
-        "default": "127.0.0.1"
-      },
-      "port": {
-        "title": "Port",
-        "type": "IntType",
-        "description": "The port to connect to.",
-        "default": 502
-      },
-      "retry": {
-        "title": "Number of Retries before Error",
-        "type": "IntType",
-        "description": "How many times to retry connection on failure.",
-        "default": 10
-      },
-      "retry_options": {
-        "title": "Retry Options",
-        "type": "ObjectType",
-        "description": "Configurables for retry attempts.",
-        "default": {
-          "strategy": "linear",
-          "max_retry": 5,
-          "multiplier": 1,
-          "indefinite": false
-        }
-      },
-      "unit_id": {
-        "title": "Unit ID",
-        "type": "IntType",
-        "description": "ID of modbus unit",
-        "default": 1
-      },
-      "value": {
-        "title": "Write Value(s)",
-        "type": "Type",
-        "description": "The value to write to the specified address.",
-        "default": "{{ True }}"
-      }
-    },
-    "inputs": {
-      "default": {
-        "description": "Drive reads and writes with input signals."
-      }
-    },
-    "outputs": {
-      "default": {
-        "description": "Notifies a signal for each frame read from Modbus."
-      }
-    },
-    "commands": {}
+    "tags": "".
+    "from_readme": "docs/modbus_tcp.md"
+    "from_python": "modbus_tcp_block.ModbusTCP"
   }
 }

--- a/tests/test_modbus_tcp_block.py
+++ b/tests/test_modbus_tcp_block.py
@@ -8,11 +8,11 @@ from nio.testing.block_test_case import NIOBlockTestCase
 from nio.signal.base import Signal
 from nio.util.threading import spawn
 
-pymodbus3_available = True
+pymodbus_available = True
 try:
-    import pymodbus3
+    import pymodbus
 except ImportError:
-    pymodbus3_available = False
+    pymodbus_available = False
 
 try:
     from ..modbus_tcp_block import ModbusTCP
@@ -27,10 +27,10 @@ class SampleResponse():
         self.value = value
 
 
-@skipUnless(pymodbus3_available, 'pymodbus3 is not available!!')
+@skipUnless(pymodbus_available, 'pymodbus is not available!!')
 class TestModbusTCP(NIOBlockTestCase):
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_defaults(self, mock_client):
         ''' Test that read_coils is called with default configuration '''
         blk = ModbusTCP()
@@ -48,7 +48,7 @@ class TestModbusTCP(NIOBlockTestCase):
             self.last_notified[DEFAULT_TERMINAL][0].value, 'default')
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_enrich_signals_mixin(self, mock_client):
         ''' Test that read_coils is called with default configuration '''
         blk = ModbusTCP()
@@ -70,7 +70,7 @@ class TestModbusTCP(NIOBlockTestCase):
             })
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_multiple_hosts(self, mock_client):
         ''' Test that read_coils is called for each client'''
         blk = ModbusTCP()
@@ -98,7 +98,7 @@ class TestModbusTCP(NIOBlockTestCase):
         self.assertEqual(self.last_notified[DEFAULT_TERMINAL][1].value, '2')
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_write_coil(self, mock_client):
         ''' Test write_coil function '''
         blk = ModbusTCP()
@@ -117,7 +117,7 @@ class TestModbusTCP(NIOBlockTestCase):
             self.last_notified[DEFAULT_TERMINAL][0].value, 'default')
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_modbus_function_from_input_signal(self, mock_client):
         ''' Attributes on input signals can be used to pick modbus function '''
         blk = ModbusTCP()
@@ -136,7 +136,7 @@ class TestModbusTCP(NIOBlockTestCase):
             self.last_notified[DEFAULT_TERMINAL][0].value, 'default')
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_exception_code(self, mock_client):
         ''' Test output signal when response contains an exception_code '''
         blk = ModbusTCP()
@@ -154,7 +154,7 @@ class TestModbusTCP(NIOBlockTestCase):
             'are not allowed or do not exist in slave')
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_execute_retry_success(self, mock_client):
         ''' Test behavior when execute retry works '''
         blk = ModbusTCP()
@@ -176,7 +176,7 @@ class TestModbusTCP(NIOBlockTestCase):
         self.assertEqual(mock_client.call_count, 2)
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_execute_retry_fails(self, mock_client):
         ''' Test behavior when execute retry fails and runs out of retries '''
         blk = ModbusTCP()
@@ -191,7 +191,7 @@ class TestModbusTCP(NIOBlockTestCase):
                 'input': 'signal'})
         blk.stop()
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_limit_lock(self, mock_client):
         ''' Test that signals are dropped when the max locks is reached '''
         blk = ModbusTCP()
@@ -234,7 +234,7 @@ class TestModbusTCP(NIOBlockTestCase):
         blk._check_exceptions(signal)
         self.assertFalse(hasattr(signal, 'exception_details'))
 
-    @patch('pymodbus3.client.sync.ModbusTcpClient')
+    @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_host_and_port_from_signal(self, mock_client):
         ''' Test that host and port evaluate using the incoming signal '''
         blk = ModbusTCP()

--- a/tests/test_modbus_tcp_block.py
+++ b/tests/test_modbus_tcp_block.py
@@ -35,7 +35,7 @@ class TestModbusTCP(NIOBlockTestCase):
         ''' Test that read_coils is called with default configuration '''
         blk = ModbusTCP()
         self.configure_block(blk, {})
-        self.assertEqual(mock_client.call_count, 1)
+        mock_client.assert_called_once_with('127.0.0.1', port=502, timeout=1)
         # Simulate some response from the modbus read
         blk._client(blk.host(),blk.port()).read_coils.return_value = SampleResponse()
         blk.start()
@@ -47,6 +47,15 @@ class TestModbusTCP(NIOBlockTestCase):
         self.assertEqual(
             self.last_notified[DEFAULT_TERMINAL][0].value, 'default')
         blk.stop()
+
+    @patch('pymodbus.client.sync.ModbusTcpClient')
+    def test_timeout(self, mock_client):
+        ''' Test that client is instantiated with configured value '''
+        blk = ModbusTCP()
+        self.configure_block(blk, {'timeout': 3.14})
+        mock_client.assert_called_once_with('127.0.0.1',
+                                            port=502,
+                                            timeout=3.14)
 
     @patch('pymodbus.client.sync.ModbusTcpClient')
     def test_enrich_signals_mixin(self, mock_client):


### PR DESCRIPTION
Updating the pymodbus package to the official source (now with py3 support!) adds support for timeout param. Technically this could have been done in another way using the old pymodbus3 library, but it's no longer necessary to use that one at all.